### PR TITLE
chore: use tailwind postcss plugin

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,5 +1,7 @@
+import tailwindcss from '@tailwindcss/postcss';
+
 const config = {
-  plugins: ["@tailwindcss/postcss"],
+  plugins: [tailwindcss()],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` plugin in PostCSS config

## Testing
- `npm run lint`
- `npm run build` *(fails: An unknown PostCSS plugin was provided; Module not found: Can't resolve 'service-worker.js')*

------
https://chatgpt.com/codex/tasks/task_e_68bea48537e48324b73a2f90b88c255d